### PR TITLE
Check chat filter on message edit

### DIFF
--- a/events/messageUpdate.js
+++ b/events/messageUpdate.js
@@ -17,11 +17,11 @@ module.exports = async (client, oldMessage, newMessage) => {
 
   const embed = new Discord.MessageEmbed()
     .setColor('#00e5ff')
-    .setAuthor(newMessage.author.tag, newMessage.author.displayAvatarURL())
+    .setAuthor({ name: newMessage.author.tag, iconURL: newMessage.author.displayAvatarURL() })
     .setDescription(`[Jump to message in](${newMessage.url} 'Jump') <#${newMessage.channelId}>`)
     .setTimestamp()
-    .setFooter(`ID: ${newMessage.author.id}`)
-    .addField('**Message Edited**', `**Before:** ${oldMsg}\n**After:** ${newMsg}`)
+    .setFooter({ text: `ID: ${newMessage.author.id}` })
+    .addField('**Message Edited**', `**Before:** ${oldMsg}\n**+After:** ${newMsg}`)
     .addField('**Posted**', `<t:${Math.floor(oldMessage.createdTimestamp / 1000)}>`);
 
   newMessage.guild.channels.cache.get(client.config.actionLog).send({ embeds: [embed] });


### PR DESCRIPTION
Currently the bot only checks for banned words when a message is sent and not when it is edited which can be used to bypass the chat filter. For example by sending a message that is not banned and editing it to something that is